### PR TITLE
initial version of internal messaging fix

### DIFF
--- a/examples/routingExample.js
+++ b/examples/routingExample.js
@@ -1,0 +1,29 @@
+import { Node } from '../src'
+
+//    znode3
+//      /\
+//     /  \
+//    /    \
+// znode1  znode2
+
+(async function () {
+  let znode3 = new Node({bind: 'tcp://127.0.0.1:3000'})
+  let znode1 = new Node()
+  let znode2 = new Node()
+
+  await znode3.bind()
+  await znode1.connect({ address: znode3.getAddress() })
+  await znode2.connect({ address: znode3.getAddress() })
+
+  znode2.onRequest('foo', ({ body, reply }) => {
+    console.log(body)
+    reply('reply from znode2.')
+  })
+
+  let rep = await znode1.requestAny({
+    event: 'foo',
+    data: 'request from znode1.'
+  })
+
+  console.log(rep)
+}())

--- a/src/client.js
+++ b/src/client.js
@@ -102,7 +102,7 @@ export default class Client extends DealerSocket {
 
   request ({ event, data, timeout, mainEvent } = {}) {
     let server = this.getServerActor()
-
+  
     // this is first request, and there is no need to check if server online or not
     if (mainEvent && event === events.CLIENT_CONNECTED) {
       return super.request({ event, data, timeout, mainEvent })
@@ -113,6 +113,7 @@ export default class Client extends DealerSocket {
       return Promise.reject(new ZeronodeError({ socketId: this.getId(), error: serverOfflineError, code: ErrorCodes.SERVER_IS_OFFLINE }))
     }
 
+    // console.log("AVAR::REQUEST server", server);
     return super.request({ event, data, timeout, to: server.getId(), mainEvent })
   }
 
@@ -124,6 +125,7 @@ export default class Client extends DealerSocket {
       return Promise.reject(new ZeronodeError({ socketId: this.getId(), error: serverOfflineError, code: ErrorCodes.SERVER_IS_OFFLINE }))
     }
 
+    // console.log("AVAR::TICK server", server);
     super.tick({ event, data, to: server.getId(), mainEvent })
   }
 }

--- a/src/metric.js
+++ b/src/metric.js
@@ -326,7 +326,7 @@ export default class Metric {
     if (!request) return
 
     request.success = true
-    request.duration = envelop.data.duration
+    request.duration = envelop.context.duration
     request.size.push(envelop.size)
     sendRequestCollection.update(request)
 
@@ -344,7 +344,7 @@ export default class Metric {
     if (!request) return
 
     request.error = true
-    request.duration = envelop.data.duration
+    request.duration = envelop.context.duration
     request.size.push(envelop.size)
     sendRequestCollection.update(request)
   }

--- a/src/sockets/dealer.js
+++ b/src/sockets/dealer.js
@@ -187,7 +187,7 @@ export default class DealerSocket extends Socket {
     socket.close()
   }
 
-  getSocketMsg (envelop) {
-    return envelop.getBuffer()
+  getSocketMsg (buffer) {
+    return buffer
   }
 }

--- a/src/sockets/router.js
+++ b/src/sockets/router.js
@@ -120,7 +120,7 @@ export default class RouterSocket extends Socket {
     return super.tick(envelop)
   }
 
-  getSocketMsg (envelop) {
-    return [envelop.getRecipient(), '', envelop.getBuffer()]
+  getSocketMsg (buffer, recipient) {
+    return [recipient, '', buffer]
   }
 }


### PR DESCRIPTION
Before all of the messages were extracted but now only the meta part is parsed and the other (data ) part could be used as buffer.
Optimization for routing cases (built in meta with enough info about the envelope route)
Context is a place for enhancements - so we can parse and read it on node
Internal routing for simple yet cool cases implemented
Merged with pattern-emitter-ts